### PR TITLE
feat(agent): local private keys

### DIFF
--- a/crates/snot-common/src/lib.rs
+++ b/crates/snot-common/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod rpc;
+pub mod set;
 pub mod state;
 pub use lasso;
 
 pub mod prelude {
     pub use crate::rpc::*;
+    pub use crate::set::*;
     pub use crate::state::*;
 }
 

--- a/crates/snot-common/src/rpc/agent.rs
+++ b/crates/snot-common/src/rpc/agent.rs
@@ -45,6 +45,8 @@ pub enum ReconcileError {
     StorageAcquireError,
     #[error("failed to resolve addresses of stated peers")]
     ResolveAddrError(ResolveError),
+    #[error("agent did not provide a local private key")]
+    NoLocalPrivateKey,
     #[error("unknown error")]
     Unknown,
 }

--- a/crates/snot-common/src/set.rs
+++ b/crates/snot-common/src/set.rs
@@ -1,0 +1,10 @@
+pub const MASK_PREFIX_LEN: usize = 5;
+
+#[repr(usize)]
+pub enum MaskBit {
+    Validator = 0,
+    Prover = 1,
+    Client = 2,
+    Compute = 3,
+    LocalPrivateKey = 4,
+}

--- a/crates/snot/src/cannon/source.rs
+++ b/crates/snot/src/cannon/source.rs
@@ -197,14 +197,14 @@ impl TxSource {
                 let sample_pk = || {
                     private_keys
                         .get(rand::random::<usize>() % private_keys.len())
-                        .and_then(|k| env.storage.sample_keysource_pk(k))
+                        .and_then(|k| env.storage.sample_keysource_pk(k).try_string())
                         .ok_or(anyhow!("error selecting a valid private key"))
                 };
                 let sample_addr = || {
                     addresses
                         .get(rand::random::<usize>() % addresses.len())
-                        .and_then(|k| env.storage.sample_keysource_addr(k))
-                        .ok_or(anyhow!("error selecting a valid private key"))
+                        .and_then(|k| env.storage.sample_keysource_addr(k).try_string())
+                        .ok_or(anyhow!("error selecting a valid address"))
                 };
 
                 let Some(mode) = tx_modes

--- a/crates/snot/src/env/mod.rs
+++ b/crates/snot/src/env/mod.rs
@@ -442,7 +442,8 @@ pub async fn initial_reconcile(env_id: usize, state: &GlobalState) -> anyhow::Re
             node_state.private_key = node
                 .key
                 .as_ref()
-                .and_then(|key| env.storage.lookup_keysource_pk(key));
+                .map(|key| env.storage.lookup_keysource_pk(key))
+                .unwrap_or_default();
 
             let not_me = |agent: &AgentPeer| !matches!(agent, AgentPeer::Internal(candidate_id, _) if *candidate_id == id);
 

--- a/crates/snot/src/env/set.rs
+++ b/crates/snot/src/env/set.rs
@@ -8,6 +8,7 @@ use indexmap::IndexMap;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use snot_common::{
     lasso::Spur,
+    set::MASK_PREFIX_LEN,
     state::{AgentId, NodeKey},
 };
 use thiserror::Error;
@@ -141,8 +142,8 @@ fn _find_compute_agent_by_mask<'a, I: Iterator<Item = &'a Agent>>(
     labels: &[Spur],
 ) -> Option<(&'a Agent, Arc<Busy>)> {
     // replace with
-    let mut mask = FixedBitSet::with_capacity(labels.len() + 4);
-    mask.insert_range(4..labels.len() + 4);
+    let mut mask = FixedBitSet::with_capacity(labels.len() + MASK_PREFIX_LEN);
+    mask.insert_range(MASK_PREFIX_LEN..labels.len() + MASK_PREFIX_LEN);
 
     agents.find_map(|agent| {
         AgentMapping::new(BusyMode::Compute, agent, labels)

--- a/scripts/agent.sh
+++ b/scripts/agent.sh
@@ -25,3 +25,5 @@ cargo run --release -p snot-agent -- \
   --labels "local,local-$INDEX" \
   --client --validator --compute \
   $@
+
+# --private-key-file "$DATA_PATH/key" \

--- a/specs/test-4-validators.yaml
+++ b/specs/test-4-validators.yaml
@@ -15,6 +15,7 @@ nodes:
   validator/test:
     replicas: 4
     key: committee.$
+    # key: local
     height: 0
     validators: [validator/*]
     peers: []


### PR DESCRIPTION
- allow agents to provide local private keys via cli flags (--private-key-file added to runner and agent cli, the key is never actually loaded on the agent)
- control plane will select agents configured with private keys when the env requires it (in addition to checking labels/mode)
- node topology can specify `key: local` instead of `key: APrivateKey..` or `key: committee.$`

other refactors:
- better mask generation (an enum specifies which bit denotes what)
- slightly cleaner cli flag storage on agents on control plane
