### PR TITLE
Fix CI nightly version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: ./snarkos-test
         env:
           RUSTFLAGS: -Zcodegen-backend=cranelift
-        run: cargo +nightly build --verbose
+        run: cargo +nightly-2024-04-01 build --verbose
 
   test:
     runs-on: ubuntu-latest
@@ -92,4 +92,4 @@ jobs:
         working-directory: ./snarkos-test
         env:
           RUSTFLAGS: -Zcodegen-backend=cranelift
-        run: cargo +nightly nextest run --all --verbose --fail-fast
+        run: cargo +nightly-2024-04-01 nextest run --all --verbose --fail-fast


### PR DESCRIPTION
Rollback nightly to a version where cranelift was working. We can remove this in the future.

Closes #99 