### PR TITLE
Refactor(Snops): Flattten error object

### DIFF
--- a/crates/snops/src/env/error.rs
+++ b/crates/snops/src/env/error.rs
@@ -1,8 +1,7 @@
 use axum::http::StatusCode;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use snops_common::{
-    impl_into_status_code, impl_serialize_pretty_error,
-    rpc::error::PrettyError,
+    impl_into_status_code, impl_into_type_str,
     state::{AgentId, NodeKey},
 };
 use strum_macros::AsRefStr;
@@ -25,11 +24,11 @@ pub enum ExecutionError {
     AgentOffline,
     #[error("env `{0}` not found")]
     EnvNotFound(usize),
-    #[error("cannon error: `{0}`")]
+    #[error(transparent)]
     Cannon(#[from] CannonError),
-    #[error("join error: `{0}`")]
+    #[error("{0}")]
     Join(#[from] JoinError),
-    #[error("reconcile error: `{0}`")]
+    #[error(transparent)]
     Reconcile(#[from] BatchReconcileError),
     #[error("env timeline is already being executed")]
     TimelineAlreadyStarted,
@@ -43,16 +42,21 @@ impl_into_status_code!(ExecutionError, |value| match value {
     _ => StatusCode::INTERNAL_SERVER_ERROR,
 });
 
+impl_into_type_str!(ExecutionError, |value| match value {
+    Cannon(e) => format!("{}.{}", value.as_ref(), &String::from(e)),
+    _ => value.as_ref().to_string(),
+});
+
 impl Serialize for ExecutionError {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         let mut state = serializer.serialize_struct("Error", 2)?;
-        state.serialize_field("type", self.as_ref())?;
+        state.serialize_field("type", &String::from(self))?;
 
         match self {
-            Self::Cannon(e) => state.serialize_field("error", e),
+            Self::Cannon(e) => state.serialize_field("error", &e.to_string()),
             _ => state.serialize_field("error", &self.to_string()),
         }?;
 
@@ -83,8 +87,6 @@ impl_into_status_code!(DelegationError, |value| match value {
     }
 });
 
-impl_serialize_pretty_error!(DelegationError);
-
 #[derive(Debug, Error, AsRefStr)]
 pub enum PrepareError {
     #[error("duplicate node key: {0}")]
@@ -95,7 +97,7 @@ pub enum PrepareError {
     MissingStorage,
     #[error("cannot have a node with zero replicas")]
     NodeHas0Replicas,
-    #[error("reconcile error: `{0}`")]
+    #[error(transparent)]
     Reconcile(#[from] ReconcileError),
 }
 
@@ -105,16 +107,21 @@ impl_into_status_code!(PrepareError, |value| match value {
     Reconcile(e) => e.into(),
 });
 
+impl_into_type_str!(PrepareError, |value| match value {
+    Reconcile(e) => format!("{}.{}", value.as_ref(), e.as_ref()),
+    _ => value.as_ref().to_string(),
+});
+
 impl Serialize for PrepareError {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         let mut state = serializer.serialize_struct("Error", 2)?;
-        state.serialize_field("type", self.as_ref())?;
+        state.serialize_field("type", &String::from(self))?;
 
         match self {
-            Self::Reconcile(e) => state.serialize_field("error", e),
+            Self::Reconcile(e) => state.serialize_field("error", &e.to_string()),
             _ => state.serialize_field("error", &self.to_string()),
         }?;
 
@@ -129,7 +136,6 @@ pub enum CleanupError {
 }
 
 impl_into_status_code!(CleanupError, |_| StatusCode::NOT_FOUND);
-impl_serialize_pretty_error!(CleanupError);
 
 #[derive(Debug, Error, AsRefStr)]
 pub enum ReconcileError {
@@ -146,23 +152,21 @@ impl_into_status_code!(ReconcileError, |value| match value {
     EnvNotFound(_) | ExpectedInternalAgentPeer { .. } => StatusCode::NOT_FOUND,
 });
 
-impl_serialize_pretty_error!(ReconcileError);
-
 #[derive(Debug, Error, AsRefStr)]
 pub enum EnvError {
-    #[error("cannon error: `{0}`")]
+    #[error(transparent)]
     Cannon(#[from] CannonError),
-    #[error("cleanup error: `{0}`")]
+    #[error(transparent)]
     Cleanup(#[from] CleanupError),
     #[error("delegation errors occured:{}", .0.iter().map(ToString::to_string).collect::<Vec<_>>().join("\n"))]
     Delegation(Vec<DelegationError>),
-    #[error("exec error: `{0}`")]
+    #[error(transparent)]
     Execution(#[from] ExecutionError),
-    #[error("prepare error: `{0}`")]
+    #[error(transparent)]
     Prepare(#[from] PrepareError),
-    #[error("reconcile error: `{0}`")]
+    #[error(transparent)]
     Reconcile(#[from] ReconcileError),
-    #[error("schema error: `{0}`")]
+    #[error(transparent)]
     Schema(#[from] SchemaError),
 }
 
@@ -176,23 +180,28 @@ impl_into_status_code!(EnvError, |value| match value {
     Schema(e) => e.into(),
 });
 
+impl_into_type_str!(EnvError, |value| match value {
+    Cannon(e) => format!("{}.{}", value.as_ref(), String::from(e)),
+    Cleanup(e) => format!("{}.{}", value.as_ref(), e.as_ref()),
+    Delegation(e) => format!(
+        "{}.{}",
+        value.as_ref(),
+        e.iter().map(|x| x.as_ref()).collect::<Vec<_>>().join(",")
+    ),
+    Execution(e) => format!("{}.{}", value.as_ref(), String::from(e)),
+    Prepare(e) => format!("{}.{}", value.as_ref(), String::from(e)),
+    Reconcile(e) => format!("{}.{}", value.as_ref(), e.as_ref()),
+    Schema(e) => format!("{}.{}", value.as_ref(), String::from(e)),
+});
+
 impl Serialize for EnvError {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         let mut state = serializer.serialize_struct("Error", 2)?;
-        state.serialize_field("type", self.as_ref())?;
-
-        match self {
-            Self::Cannon(e) => state.serialize_field("error", e),
-            Self::Cleanup(e) => state.serialize_field("error", e),
-            Self::Delegation(e) => state.serialize_field("error", e),
-            Self::Execution(e) => state.serialize_field("error", e),
-            Self::Prepare(e) => state.serialize_field("error", e),
-            Self::Reconcile(e) => state.serialize_field("error", e),
-            Self::Schema(e) => state.serialize_field("error", e),
-        }?;
+        state.serialize_field("type", &String::from(self))?;
+        state.serialize_field("error", &self.to_string())?;
 
         state.end()
     }

--- a/crates/snops/src/error.rs
+++ b/crates/snops/src/error.rs
@@ -1,22 +1,21 @@
 use std::process::ExitStatus;
 
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use snops_common::rpc::error::PrettyError;
 use snops_common::state::AgentId;
-use snops_common::{impl_into_status_code, impl_serialize_pretty_error};
+use snops_common::{impl_into_status_code, impl_into_type_str};
 use strum_macros::AsRefStr;
 use thiserror::Error;
 
 #[derive(Debug, Error, AsRefStr)]
 pub enum CommandError {
-    #[error("error {action} command `{cmd}`: {error}")]
+    #[error("{action} command `{cmd}`: {error}")]
     Action {
         action: &'static str,
         cmd: &'static str,
         #[source]
         error: std::io::Error,
     },
-    #[error("error command `{cmd}` failed with `{status}`: {stderr}")]
+    #[error("command `{cmd}` failed with `{status}`: {stderr}")]
     Status {
         cmd: &'static str,
         status: ExitStatus,
@@ -25,7 +24,6 @@ pub enum CommandError {
 }
 
 impl_into_status_code!(CommandError);
-impl_serialize_pretty_error!(CommandError);
 
 impl CommandError {
     pub fn action(action: &'static str, cmd: &'static str, error: std::io::Error) -> Self {
@@ -42,7 +40,7 @@ impl CommandError {
 }
 
 #[derive(Debug, Error)]
-#[error("deserialize error: `{i}`: `{e}`")]
+#[error("`{i}`: `{e}`")]
 pub struct DeserializeError {
     pub i: usize,
     #[source]
@@ -53,13 +51,13 @@ impl_into_status_code!(DeserializeError);
 
 #[derive(Debug, Error, AsRefStr)]
 pub enum StateError {
-    #[error("common agent error: {0}")]
+    #[error(transparent)]
     Agent(#[from] snops_common::prelude::error::AgentError),
     #[error("source agent has no addr id: `{0}`")]
     NoAddress(AgentId),
-    #[error("common reconcile error: {0}")]
+    #[error(transparent)]
     Reconcile(#[from] snops_common::prelude::error::ReconcileError),
-    #[error("rpc error: {0}")]
+    #[error("{0}")]
     Rpc(#[from] tarpc::client::RpcError),
     #[error("source agent not found id: `{0}`")]
     SourceAgentNotFound(AgentId),
@@ -67,25 +65,20 @@ pub enum StateError {
 
 impl_into_status_code!(StateError);
 
+impl_into_type_str!(StateError, |value| match value {
+    Agent(e) => format!("{}.{}", value.as_ref(), e.as_ref()),
+    Reconcile(e) => format!("{}.{}", value.as_ref(), e.as_ref()),
+    _ => value.as_ref().to_string(),
+});
+
 impl Serialize for StateError {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         let mut state = serializer.serialize_struct("Error", 2)?;
-        state.serialize_field("type", self.as_ref())?;
-
-        match self {
-            Self::Agent(e) => {
-                let pe = PrettyError::from(e);
-                state.serialize_field("error", &pe)
-            }
-            Self::Reconcile(e) => {
-                let pe = PrettyError::from(e);
-                state.serialize_field("error", &pe)
-            }
-            _ => state.serialize_field("error", &self.to_string()),
-        }?;
+        state.serialize_field("type", &String::from(self))?;
+        state.serialize_field("error", &self.to_string())?;
 
         state.end()
     }

--- a/crates/snops/src/schema/error.rs
+++ b/crates/snops/src/schema/error.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use axum::http::StatusCode;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
-use snops_common::{impl_into_status_code, impl_serialize_pretty_error, rpc::error::PrettyError};
+use snops_common::{impl_into_status_code, impl_into_type_str};
 use strum_macros::AsRefStr;
 use thiserror::Error;
 use url::Url;
@@ -11,23 +11,23 @@ use crate::error::CommandError;
 
 #[derive(Debug, Error, AsRefStr)]
 pub enum StorageError {
-    #[error("command error id: `{0}`: {1}")]
+    #[error("storage id: `{1}`: {0}")]
     Command(CommandError, String),
-    #[error("error mkdirs for storage generation id: `{0}`: {1}")]
+    #[error("mkdirs for storage generation id: `{0}`: {1}")]
     GenerateStorage(String, #[source] std::io::Error),
-    #[error("error generating genesis id: `{0}`: {1}")]
+    #[error("generating genesis id: `{0}`: {1}")]
     FailedToGenGenesis(String, #[source] std::io::Error),
-    #[error("error fetching genesis block id: `{0}` url: `{1}`: {2}")]
+    #[error("fetching genesis block id: `{0}` url: `{1}`: {2}")]
     FailedToFetchGenesis(String, Url, #[source] reqwest::Error),
-    #[error("error writing genesis block id: `{0}`: {1}")]
+    #[error("writing genesis block id: `{0}`: {1}")]
     FailedToWriteGenesis(String, #[source] std::io::Error),
-    #[error("error taring ledger id: `{0}`: {1}")]
+    #[error("taring ledger id: `{0}`: {1}")]
     FailedToTarLedger(String, #[source] std::io::Error),
     #[error("the specified storage ID {0} doesn't exist, and no generation params were specified")]
     NoGenerationParams(String),
-    #[error("error reading balances {0:#?}: {1}")]
+    #[error("reading balances {0:#?}: {1}")]
     ReadBalances(PathBuf, #[source] std::io::Error),
-    #[error("error parsing balances {0:#?}: {1}")]
+    #[error("parsing balances {0:#?}: {1}")]
     ParseBalances(PathBuf, #[source] serde_json::Error),
 }
 
@@ -38,7 +38,10 @@ impl_into_status_code!(StorageError, |value| match value {
     _ => StatusCode::INTERNAL_SERVER_ERROR,
 });
 
-impl_serialize_pretty_error!(StorageError);
+impl_into_type_str!(StorageError, |value| match value {
+    Command(e, _) => format!("{}.{}", value.as_ref(), e.as_ref()),
+    _ => value.as_ref().to_string(),
+});
 
 #[derive(Debug, Error)]
 #[error("invalid node target string")]
@@ -59,15 +62,13 @@ impl_into_status_code!(KeySourceError, |value| match value {
     InvalidCommitteeIndex(_) => StatusCode::BAD_REQUEST,
 });
 
-impl_serialize_pretty_error!(KeySourceError);
-
 #[derive(Debug, Error, AsRefStr)]
 pub enum SchemaError {
     #[error("key source error: {0}")]
     KeySource(#[from] KeySourceError),
-    #[error("node target error: {0}")]
+    #[error(transparent)]
     NodeTarget(#[from] NodeTargetError),
-    #[error("storage error: {0}")]
+    #[error(transparent)]
     Storage(#[from] StorageError),
 }
 
@@ -77,19 +78,20 @@ impl_into_status_code!(SchemaError, |value| match value {
     Storage(e) => e.into(),
 });
 
+impl_into_type_str!(SchemaError, |value| match value {
+    KeySource(e) => format!("{}.{}", value.as_ref(), e.as_ref()),
+    Storage(e) => format!("{}.{}", value.as_ref(), String::from(e)),
+    _ => value.as_ref().to_string(),
+});
+
 impl Serialize for SchemaError {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         let mut state = serializer.serialize_struct("Error", 2)?;
-        state.serialize_field("type", self.as_ref())?;
-
-        match self {
-            Self::KeySource(e) => state.serialize_field("error", e),
-            Self::NodeTarget(e) => state.serialize_field("error", &e.to_string()),
-            Self::Storage(e) => state.serialize_field("error", e),
-        }?;
+        state.serialize_field("type", &String::from(self))?;
+        state.serialize_field("error", &self.to_string())?;
 
         state.end()
     }

--- a/crates/snops/src/schema/storage.rs
+++ b/crates/snops/src/schema/storage.rs
@@ -197,6 +197,8 @@ impl Document {
         let mut base = state.cli.path.join("storage");
         base.push(&id);
 
+        // TODO: The dir can be made by a previous run and the aot stuff can fail
+        // i.e an empty/incomplete directory can exist and we should check those
         let exists = matches!(tokio::fs::try_exists(&base).await, Ok(true));
 
         // TODO: respect self.prefer_existing
@@ -400,6 +402,8 @@ fn pick_commitee_addr(entry: (String, u64)) -> String {
     entry.0
 }
 
+// TODO: function should also take storage id
+// in case of error, the storage id can be used to provide more context
 async fn read_to_addrs<T: DeserializeOwned>(
     f: impl Fn(T) -> String,
     file: PathBuf,


### PR DESCRIPTION
Flattens the errors for snops.

Examples:
![image](https://github.com/monadicus/snarkos-test/assets/16431709/5ef6eb23-69d8-45af-820a-4c272240934e)

![image](https://github.com/monadicus/snarkos-test/assets/16431709/872ff879-bc78-4aaa-a7bb-ad358d95094e)

