### PR TITLE
chore: temporarily disable clippy in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -122,11 +122,11 @@ jobs:
       - name: ☁️ Install cargo-machete
         run: cargo install cargo-machete
 
-      - name: 📋 Clippy Check
-        working-directory: ./snarkos-test
-        env:
-          RUSTFLAGS: -Zcodegen-backend=cranelift
-        run: cargo +nightly-2024-04-01 clippy --all --all-targets -- -D warnings
+      # - name: 📋 Clippy Check
+      #   working-directory: ./snarkos-test
+      #   env:
+      #     RUSTFLAGS: -Zcodegen-backend=cranelift
+      #   run: cargo +nightly-2024-04-01 clippy --all --all-targets -- -D warnings
 
       - name: 📋 Check Unused Deps
         if: always()


### PR DESCRIPTION
Temporarily disable Clippy in the GitHub CI until MVP.