### PR TITLE
build: use rewind panic mode for tokio to prevent crashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ codegen-units = 1
 incremental = true
 lto = "fat"
 opt-level = 3
-panic = "abort"
+panic = "unwind"
 strip = true
 
 # For testing cargo bloat


### PR DESCRIPTION
<!--
	Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

	Please help us understand your motivation by explaining why you decided to make this change.

	Happy contributing!
-->

## Motivation

nodes would crash without this setting

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

change a Cargo.toml setting that impacts tokio's handling of panics

## Testing

<!--
	How do you test these changes?
	What command do you run to test these changes specifically?
-->

VM didn't halt the entire node on panic with this enabled

## Related PRs and Issues

<!--
	Please link to any relevant Issues and PRs.
-->

n/a
