### PR TITLE
fix: make build cmds

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -96,14 +96,13 @@ args = ["-rf", "./target/*-compressed"]
 description = "Build the AOT binary"
 toolchain = "nightly"
 dependencies = ["install-rust-src"]
-env = { RUSTFLAGS = "-C panic=abort -Zlocation-detail=none" }
+env = { RUSTFLAGS = "-Zlocation-detail=none" }
 command = "cargo"
 args = [
 	"build",
 	"-p",
 	"snarkos-aot",
-	"-Zbuild-std=std,panic_abort",
-	"-Zbuild-std-features=panic_immediate_abort",
+	"-Zbuild-std=std",
 	"--profile",
 	"release-small",
 	"--target",
@@ -135,7 +134,7 @@ args = [
 	"-Zbuild-std=std,panic_abort",
 	"-Zbuild-std-features=panic_immediate_abort",
 	"--profile",
-	"release",
+	"release-big",
 	"--target",
 	"x86_64-unknown-linux-gnu",
 ]
@@ -194,7 +193,7 @@ args = [
 	"snops-cli",
 	"-Zbuild-std=std,panic_abort",
 	"-Zbuild-std-features=panic_immediate_abort",
-	"--profile",
+	"--profile-big",
 	"release",
 	"--target",
 	"x86_64-unknown-linux-gnu",


### PR DESCRIPTION
… and snops

<!--
	Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

	Please help us understand your motivation by explaining why you decided to make this change.

	Happy contributing!
-->

## Motivation

To have the make commands fix some issues:
- aot relies on panics for snarkos
- use release-big where appropriate

## Explanation of Changes

Remove panic things for aot.

## Testing

<!--
	How do you test these changes?
	What command do you run to test these changes specifically?
-->

Tested commands still work.

## Related PRs and Issues

<!--
	Please link to any relevant Issues and PRs.
-->

N/A
