### PR TITLE
fix: node type bit

### DIFF
--- a/crates/snops-common/src/state/node_type.rs
+++ b/crates/snops-common/src/state/node_type.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsStr;
 
-use crate::format::DataFormat;
+use crate::{format::DataFormat, prelude::MaskBit};
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -36,7 +36,11 @@ impl NodeType {
     }
 
     pub fn bit(self) -> usize {
-        self as usize
+        (match self {
+            Self::Validator => MaskBit::Validator,
+            Self::Prover => MaskBit::Prover,
+            Self::Client => MaskBit::Client,
+        }) as usize
     }
 }
 


### PR DESCRIPTION
Fixes node type bit regression, ensuring `NodeType` and `MaskBit` reprs match.