### PR TITLE
feat(cli): add env auth command to cli

### DIFF
--- a/crates/snops-cli/Cargo.toml
+++ b/crates/snops-cli/Cargo.toml
@@ -17,7 +17,7 @@ clap-stdin.workspace = true
 reqwest = { workspace = true, features = ["blocking", "json"] }
 serde.workspace = true
 serde_json.workspace = true
-snops-common.workspace = true
+snops-common = { workspace = true, features = ["aot_cmds"] }
 
 [build-dependencies]
 anyhow.workspace = true

--- a/crates/snops-common/src/aot_cmds/mod.rs
+++ b/crates/snops-common/src/aot_cmds/mod.rs
@@ -1,4 +1,4 @@
-use std::{io, path::PathBuf, process::Stdio};
+use std::{io, path::PathBuf, process::Stdio, str::FromStr};
 
 use tokio::{
     io::AsyncWriteExt,
@@ -34,6 +34,14 @@ pub enum Authorization {
         #[serde(skip_serializing_if = "Option::is_none", default)]
         fee_auth: Option<Value>,
     },
+}
+
+impl FromStr for Authorization {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
 }
 
 type Output = io::Result<std::process::Output>;


### PR DESCRIPTION
a simple command that allows for offline/cold authorizations to be easily piped into snops without having to use curl

`NETWORK=testnet aot auth program ... | scli env auth --async -`

related #189