### PR TITLE
feat(snops): add private_key, env, and binary config action flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4539,6 +4539,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snops-common",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/snops-agent/src/cli.rs
+++ b/crates/snops-agent/src/cli.rs
@@ -101,6 +101,14 @@ impl Cli {
         std::process::exit(0);
     }
 
+    pub fn get_local_ip(&self) -> IpAddr {
+        if self.bind_addr.is_unspecified() {
+            IpAddr::V4(Ipv4Addr::LOCALHOST)
+        } else {
+            self.bind_addr
+        }
+    }
+
     pub fn endpoint_and_uri(&self) -> (String, Uri) {
         // get the endpoint
         let endpoint = self

--- a/crates/snops-agent/src/metrics/mod.rs
+++ b/crates/snops-agent/src/metrics/mod.rs
@@ -1,11 +1,6 @@
 pub mod tps;
 
-use std::{
-    collections::HashMap,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 
 use self::tps::TpsMetric;
 use crate::state::GlobalState;
@@ -39,7 +34,7 @@ pub fn init(state: Arc<GlobalState>) {
                 let response = match client
                     .get(format!(
                         "http://{}/",
-                        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), state.cli.ports.metrics)
+                        SocketAddr::new(state.cli.get_local_ip(), state.cli.ports.metrics)
                     ))
                     .send()
                     .await

--- a/crates/snops-agent/src/rpc/control.rs
+++ b/crates/snops-agent/src/rpc/control.rs
@@ -428,7 +428,8 @@ impl AgentService for AgentRpcServer {
             .network;
 
         let url = format!(
-            "http://127.0.0.1:{}/{network}{route}",
+            "http://{}:{}/{network}{route}",
+            self.state.cli.get_local_ip(),
             self.state.cli.ports.rest
         );
         let response = reqwest::get(&url)
@@ -460,7 +461,8 @@ impl AgentService for AgentRpcServer {
             .network;
 
         let url = format!(
-            "http://127.0.0.1:{}/{network}/transaction/broadcast",
+            "http://{}:{}/{network}/transaction/broadcast",
+            self.state.cli.get_local_ip(),
             self.state.cli.ports.rest
         );
         let response = reqwest::Client::new()

--- a/crates/snops-cli/Cargo.toml
+++ b/crates/snops-cli/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { workspace = true, features = ["blocking", "json"] }
 serde.workspace = true
 serde_json.workspace = true
 snops-common = { workspace = true, features = ["aot_cmds"] }
+thiserror.workspace = true
 
 [build-dependencies]
 anyhow.workspace = true

--- a/crates/snops-common/src/action_models.rs
+++ b/crates/snops-common/src/action_models.rs
@@ -1,11 +1,12 @@
 use std::str::FromStr;
 
+use indexmap::{IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     key_source::KeySource,
     node_targets::{NodeTarget, NodeTargets},
-    state::{CannonId, DocHeightRequest},
+    state::{CannonId, DocHeightRequest, InternedId},
 };
 
 #[derive(Deserialize, Serialize, Clone)]
@@ -120,7 +121,12 @@ pub struct Reconfig {
     pub peers: Option<NodeTargets>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub validators: Option<NodeTargets>,
-    // TODO: private key
-    // TODO: env
-    // TODO: binary
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binary: Option<InternedId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub private_key: Option<KeySource>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub set_env: Option<IndexMap<String, String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub del_env: Option<IndexSet<String>>,
 }

--- a/crates/snops-common/src/state/node_state.rs
+++ b/crates/snops-common/src/state/node_state.rs
@@ -162,6 +162,10 @@ impl KeyState {
             _ => None,
         }
     }
+
+    pub fn is_none(&self) -> bool {
+        matches!(self, KeyState::None)
+    }
 }
 
 #[derive(


### PR DESCRIPTION
## Motivation

Being able to change `env`, node `private_key`s and binaries makes testing and reproducing issues much easier

## Explanation of Changes

- Adds new config action flags to the snops-cli
- Allows users to update a node's env, private_key, or binary

## Related PRs and Issues

- Closes #210 